### PR TITLE
add proper event handlers and default to require

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ var bootstrap =
 
 module.exports = Worker;
 function Worker(file, type) {
-  if (type === true) {
-    type = 'require';
+  if(type === true) {
+    type = "eval";
   } else {
-    type = 'eval';
+    type = "require";
   }
 
   var self = this;
@@ -19,14 +19,23 @@ function Worker(file, type) {
   if (type === 'eval') {
     file = bootstrap + '\n' + fs.readFileSync(file, 'utf8');
   }
+
   this.child.send(file);
   this.child.on('message', function (msg) {
     var parsed = JSON.parse(msg);
     self.onmessage && self.onmessage.call(self, parsed);
+    if(self.handlers['message']) {
+      self.handlers['message'].forEach(func => func.call(self, parsed));
+    }
   });
   this.child.on('error', function (err) {
     self.onerror && self.onerror(err);
+    if(self.handlers['error']) {
+      self.handlers['error'].forEach(func => func.call(self, err));
+    }
   });
+
+  this.handlers = {};
 }
 
 Worker.prototype.postMessage = function (msg) {
@@ -37,16 +46,16 @@ Worker.prototype.terminate = function() {
   this.child.kill();
 };
 
-Worker.prototype.onmessage = function () {
-};
-
-Worker.prototype.onerror = function () {
-};
-
 Worker.prototype.addEventListener = function (eventName, cb) {
-  if (eventName === 'message') {
-    this.onmessage = cb;
-  } else if (eventName === 'error') {
-    this.onerror = cb;
+  if (!this.handlers[eventName]) {
+    this.handlers[eventName] = [];
   }
+  this.handlers[eventName].push(cb);
 };
+
+Worker.prototype.removeEventListener = function(eventName, cb) {
+  const eventHandlers = this.handlers[eventName];
+  if(eventHandlers) {
+    this.handlers[eventName] = eventHandlers.filter(func => func !== cb);
+  }
+}


### PR DESCRIPTION
We need this for one of our projects, but we used `addEventListener` and `removeEventListener`. This PR properly implements those.

It also defaults to using `require` instead of `eval` because error stacks are correct. I'm not sure why `eval` was the default, and there may have been a good reason.

This project hasn't been updated in a long time, but I figured I'd open this PR anyway in case someone else needs it.
